### PR TITLE
Remove unnecessary dependency on zope.formlib

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,23 @@
 Changelog
 =========
 
-1.1.8 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Migrate package to plone5 (still using the old-style portal_javascript etc.)
+  [sunew]
+
+- Move from a skinfolder to static resources
+  [sunew]
+
+- Enable plone.protect for urls
+  [sunew]
+
+- Danish translation
+  [sunew]
+
+- Remove unnecessary dependency on zope.formlib
+  [daggelpop]
 
 
 1.1.7 (2015-04-03)

--- a/src/collective/favorites/portlet/favorites.py
+++ b/src/collective/favorites/portlet/favorites.py
@@ -2,7 +2,6 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize.instance import memoize
 from plone.portlets.interfaces import IPortletDataProvider
 from zope.component import getMultiAdapter, queryUtility, getUtilitiesFor
-from zope.formlib import form
 from zope.interface import implements
 
 from Acquisition import aq_inner
@@ -68,7 +67,7 @@ class Renderer(base.Renderer):
 
 
 class AddForm(base.NullAddForm):
-    form_fields = form.Fields(IFavoritesPortlet)
+    form_fields = IFavoritesPortlet
     label = _(u"Add Favorites Portlet")
     description = _(u"This portlet displays the documents you have selected as your favorites.")
 


### PR DESCRIPTION
Hi,

I removed the only zope.formlib use in the package, since it's not shipped with Plone 5 anymore.